### PR TITLE
Use `7z` instead of `zip` for better compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN echo $'Dpkg::Use-Pty "0";\nquiet "2";\nAPT::Install-Recommends "0";' > /etc/apt/apt.conf.d/99autopilot
 RUN apt-get update
-RUN apt-get install build-essential subversion bison autoconf ruby bundler zip curl
+RUN apt-get install build-essential subversion bison autoconf ruby bundler p7zip-full curl
 RUN apt-get upgrade && apt-get autoremove && apt-get clean
 
 ADD . /root/


### PR DESCRIPTION
tool/make-snapshot supports `7z` command if available
https://github.com/ruby/ruby/blob/86f6fa45f8a27338c9e07f5e9772a74a43a96c2c/tool/make-snapshot#L58