### PR TITLE
Fetch notes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ DIRS = %w(1.0 1.1a 1.1b 1.1c 1.1d 1.2 1.3 1.4 1.6 1.8 1.9 2.0 2.1 2.2 2.3 2.4 2.
 
 task :snapshot do
   FileUtils.mkdir "pkg" unless File.directory?("pkg")
-  `cd ruby && git checkout master && git pull origin master`
+  `cd ruby && git checkout master && git pull origin master && git fetch origin refs/notes/commits:refs/notes/commits`
   `ruby ruby/tool/make-snapshot -archname=snapshot -srcdir=ruby pkg`
   upload_s3("snapshot")
   purge_fastly("snapshot")


### PR DESCRIPTION
Fix error on export_changelog:
```
% docker run -it -v $(pwd)/pkg:/root/pkg ruby-snapshot bundle exec rake snapshot
Already on 'master'
From https://github.com/ruby/ruby
 * branch                  master     -> FETCH_HEAD
Cloning into '/tmp/ruby-snapshot20190826-37-je8moq/ruby'...
done.
Checking out files: 100% (9355/9355), done.
Traceback (most recent call last):
	6: from ruby/tool/make-snapshot:523:in `<main>'
	5: from ruby/tool/make-snapshot:523:in `collect'
	4: from ruby/tool/make-snapshot:523:in `block in <main>'
	3: from ruby/tool/make-snapshot:351:in `package'
	2: from ruby/tool/make-snapshot:351:in `chdir'
	1: from ruby/tool/make-snapshot:353:in `block in package'
/root/ruby/tool/lib/vcs.rb:573:in `export_changelog': need notes/commits tree; run `git fetch origin refs/notes/commits:refs/notes/commits` in the repository (RuntimeError)
rake aborted!
```